### PR TITLE
fix: Removed `reviewers`, since this is replaced by codeowners

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,8 +19,6 @@ updates:
     open-pull-requests-limit: 20
     # Add assignees
     assignees:
-      - "samtrion"
-    reviewers:
       - samtrion
 
   - package-ecosystem: "nuget"
@@ -34,8 +32,6 @@ updates:
     open-pull-requests-limit: 20
     # Add assignees
     assignees:
-      - "samtrion"
-    reviewers:
       - samtrion
     groups:
      coverlet:
@@ -70,7 +66,4 @@ updates:
       - "dependency:devcontainers"
     open-pull-requests-limit: 20
     # Add assignees
-    assignees:
-      - "samtrion"
-    reviewers:
       - samtrion


### PR DESCRIPTION
https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/