### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/template-sync.yml
+++ b/.github/workflows/template-sync.yml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   template-sync:
     if: github.actor != 'dependabot[bot]' && github.repository == 'dailydevops/dotnet-template'


### PR DESCRIPTION
Potential fix for [https://github.com/dailydevops/dotnet-template/security/code-scanning/1](https://github.com/dailydevops/dotnet-template/security/code-scanning/1)

The issue can be fixed by adding a `permissions` block at the workflow level (applies to all jobs) or the job level (specific to the `template-sync` job). Since the job involves checking out the repository and syncing templates, the least privileges required are `contents: read` (to read the repository content) and possibly `contents: write` (if the sync action modifies files). Additional permissions like `issues: write` or `pull-requests: write` are unnecessary unless explicitly required.

The fix should add the `permissions` block at the workflow level to enforce consistent permissions for all jobs and simplify the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
