### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/dailydevops/dotnet-template/security/code-scanning/4](https://github.com/dailydevops/dotnet-template/security/code-scanning/4)

To fix the issue, add an explicit `permissions` block to the root of the workflow file. This block will limit the permissions of the `GITHUB_TOKEN` to the minimum required for the tasks performed by the workflow. Based on the workflow's purpose (building and testing), it likely only needs read access to the repository content (`contents: read`). If additional permissions are required for specific tasks (e.g., writing pull requests or issues), they can be added explicitly.

The `permissions` block should be added at the top level of the workflow, as this ensures it applies to all jobs unless overridden by a job-specific `permissions` block. This approach centralizes permission management and minimizes redundancy.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
